### PR TITLE
feat: add transaction id and address fields to untrusted data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dscvr-one/frames-adapter",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Frames adapter to validate in DSCVR frame instances",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export type {
   DscvrFramesRequest,
   DscvrUntrustedData,
   DscvrValidationResponse,
+  UnknownFrameRequest,
 } from './types';
 export { dscvrClientProtocolPrefix } from './constants';
 export {

--- a/src/queries/validation.query.ts
+++ b/src/queries/validation.query.ts
@@ -6,12 +6,14 @@ export const validationQuery = `#graphql
         },
         content {
             id
-        }
+        },
         buttonIndex,
         state,
         url,
         timestamp,
         inputText,
+        transactionId,
+        address,
       }
     }
 `;

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@ import { dscvrClientProtocolPrefix } from './constants';
 export type DscvrUntrustedData = OpenFramesUntrustedData & {
   dscvrId: string;
   contentId?: string;
+  transactionId?: string;
+  address?: string;
   state?: string;
 };
 
@@ -42,4 +44,6 @@ export interface ValidatedQueryResult {
   timestamp: string;
   url: string;
   buttonIndex: number;
+  transactionId: string | null;
+  address: string | null;
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -98,6 +98,8 @@ export const validateDscvrFrameMessage = async (
     contentId: content?.id,
     inputText: queryResult.inputText || undefined,
     buttonIndex: queryResult.buttonIndex,
+    transactionId: queryResult.transactionId || undefined,
+    address: queryResult.address || undefined,
     state: queryResult.state || undefined,
     url: queryResult.url,
     timestamp: Number(queryResult.timestamp),


### PR DESCRIPTION
Ad transactionId and address fields to the untrusted data, query and validation response